### PR TITLE
Do not spoil oauth proxy version

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -139,14 +139,6 @@ func getTemplates() *template.Template {
 			})();
 		}
 	</script>
-	<footer>
-	{{ if eq .Footer "-" }}
-	{{ else if eq .Footer ""}}
-	Secured with <a href="https://github.com/bitly/oauth2_proxy#oauth2_proxy">OAuth2 Proxy</a> version {{.Version}}
-	{{ else }}
-	{{.Footer}}
-	{{ end }}
-	</footer>
 </body>
 </html>
 {{end}}`)


### PR DESCRIPTION
Maybe it's not the best idea to publicly announce what version of Oauth proxy we are running, especially if we run **alpha**:


<img width="682" alt="screen shot 2018-04-09 at 1 05 56 pm" src="https://user-images.githubusercontent.com/522155/38496833-daa36a64-3bf6-11e8-8186-5cb85e852db2.png">
